### PR TITLE
fix: remove broken CI hooks and harden self-review fail-open

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,3 +16,4 @@ jobs:
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
+          token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Summary
- Remove `prek` CI job (unnecessary third-party action)
- Remove `check-no-emojis` pre-commit hook (references script outside repo)
- Add proper error handling in `self-review` main so it fails-open with `{}`
- Use `GH_PAT` for release-please to allow PR creation

## Test plan
- [x] `go test ./...` passes
- [x] `gofmt -l .` clean
- [x] Pre-commit hooks pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>