### PR TITLE
feat: configurable output paths and ~/.config/hooks data dir

### DIFF
--- a/cmd/audit/main.go
+++ b/cmd/audit/main.go
@@ -29,7 +29,7 @@ func main() {
 	auditDir := os.Getenv("HOOK_AUDIT_DIR")
 	if auditDir == "" {
 		home, _ := os.UserHomeDir()
-		auditDir = filepath.Join(home, ".cursor", "audit")
+		auditDir = filepath.Join(home, ".config", "hooks", "audit")
 	}
 
 	result, code := hooks.Audit(input, auditDir)

--- a/cmd/compact-snapshot/main.go
+++ b/cmd/compact-snapshot/main.go
@@ -21,11 +21,11 @@ func main() {
 	home, _ := os.UserHomeDir()
 	auditDir := os.Getenv("HOOK_AUDIT_DIR")
 	if auditDir == "" {
-		auditDir = filepath.Join(home, ".cursor", "audit")
+		auditDir = filepath.Join(home, ".config", "hooks", "audit")
 	}
 	snapshotDir := os.Getenv("HOOK_SNAPSHOT_DIR")
 	if snapshotDir == "" {
-		snapshotDir = filepath.Join(home, ".cursor", "snapshots")
+		snapshotDir = filepath.Join(home, ".config", "hooks", "snapshots")
 	}
 
 	result, code := hooks.CompactSnapshot(input, auditDir, snapshotDir)

--- a/cmd/cost-estimator/main.go
+++ b/cmd/cost-estimator/main.go
@@ -29,7 +29,7 @@ func main() {
 	home, _ := os.UserHomeDir()
 	logDir := os.Getenv("HOOK_COST_DIR")
 	if logDir == "" {
-		logDir = filepath.Join(home, ".cursor", "cost")
+		logDir = filepath.Join(home, ".config", "hooks", "cost")
 	}
 
 	result, code := hooks.CostEstimator(input, logDir)

--- a/cmd/dry-run-mode/main.go
+++ b/cmd/dry-run-mode/main.go
@@ -31,7 +31,7 @@ func main() {
 	home, _ := os.UserHomeDir()
 	logDir := os.Getenv("HOOK_DRY_RUN_DIR")
 	if logDir == "" {
-		logDir = filepath.Join(home, ".cursor", "dry-run")
+		logDir = filepath.Join(home, ".config", "hooks", "dry-run")
 	}
 
 	result, code := hooks.DryRunMode(input, enabled, logDir)

--- a/cmd/interactive/main.go
+++ b/cmd/interactive/main.go
@@ -22,15 +22,17 @@ func main() {
 
 func runScan() {
 	fmt.Println("=== Project hooks ===")
+	var cfg *config.Config
 	configPath, workDir, err := config.FindConfigPath()
 	if err != nil {
 		fmt.Println("  (none found)")
 	} else {
 		fmt.Printf("  Config: %s\n", configPath)
 		fmt.Printf("  Work dir: %s\n", workDir)
-		cfg, err := config.Load(configPath)
+		cfg, err = config.Load(configPath)
 		if err != nil {
 			fmt.Printf("  Error loading config: %v\n", err)
+			cfg = nil
 		} else {
 			var n int
 			for _, ev := range cfg.Events() {
@@ -49,7 +51,11 @@ func runScan() {
 	}
 
 	fmt.Println("\n=== Global hooks ===")
-	globalPath := config.GlobalHooksPath()
+	var globalOverride string
+	if cfg != nil && cfg.Output != nil {
+		globalOverride = cfg.Output.GlobalDir
+	}
+	globalPath := config.GlobalHooksPath(globalOverride)
 	if info, err := os.Stat(globalPath); err == nil && !info.IsDir() {
 		fmt.Printf("  %s (present)\n", globalPath)
 	} else {

--- a/cmd/rate-limiter/main.go
+++ b/cmd/rate-limiter/main.go
@@ -37,7 +37,7 @@ func main() {
 	home, _ := os.UserHomeDir()
 	stateDir := os.Getenv("HOOK_RATE_DIR")
 	if stateDir == "" {
-		stateDir = filepath.Join(home, ".cursor", "rate")
+		stateDir = filepath.Join(home, ".config", "hooks", "rate")
 	}
 
 	result, code := hooks.RateLimiter(input, maxPerMinute, stateDir)

--- a/cmd/session-diary/main.go
+++ b/cmd/session-diary/main.go
@@ -21,11 +21,11 @@ func main() {
 	home, _ := os.UserHomeDir()
 	auditDir := os.Getenv("HOOK_AUDIT_DIR")
 	if auditDir == "" {
-		auditDir = filepath.Join(home, ".cursor", "audit")
+		auditDir = filepath.Join(home, ".config", "hooks", "audit")
 	}
 	diaryDir := os.Getenv("HOOK_DIARY_DIR")
 	if diaryDir == "" {
-		diaryDir = filepath.Join(home, ".cursor", "diary")
+		diaryDir = filepath.Join(home, ".config", "hooks", "diary")
 	}
 
 	result, code := hooks.SessionDiary(input, auditDir, diaryDir)

--- a/cmd/time-tracker-end/main.go
+++ b/cmd/time-tracker-end/main.go
@@ -21,7 +21,7 @@ func main() {
 	home, _ := os.UserHomeDir()
 	logDir := os.Getenv("HOOK_TIME_DIR")
 	if logDir == "" {
-		logDir = filepath.Join(home, ".cursor", "time")
+		logDir = filepath.Join(home, ".config", "hooks", "time")
 	}
 
 	result, code := hooks.TimeTracker(input, "end", logDir)

--- a/cmd/time-tracker-start/main.go
+++ b/cmd/time-tracker-start/main.go
@@ -21,7 +21,7 @@ func main() {
 	home, _ := os.UserHomeDir()
 	logDir := os.Getenv("HOOK_TIME_DIR")
 	if logDir == "" {
-		logDir = filepath.Join(home, ".cursor", "time")
+		logDir = filepath.Join(home, ".config", "hooks", "time")
 	}
 
 	result, code := hooks.TimeTracker(input, "start", logDir)

--- a/cmd/todo-tracker/main.go
+++ b/cmd/todo-tracker/main.go
@@ -29,7 +29,7 @@ func main() {
 	logDir := os.Getenv("HOOK_TODO_DIR")
 	if logDir == "" {
 		home, _ := os.UserHomeDir()
-		logDir = filepath.Join(home, ".cursor", "todos")
+		logDir = filepath.Join(home, ".config", "hooks", "todos")
 	}
 
 	result, code := hooks.TodoTracker(input, logDir)

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,13 @@
 
 version: 1
 
+# Output paths for generated config files
+# output:
+#   binDir: ./hooks/bin     # Command prefix for hook binaries in generated JSON
+#   cursorDir: .cursor      # Repo-level Cursor output directory
+#   claudeDir: .claude      # Repo-level Claude output directory
+#   globalDir: ~/.cursor    # Global install target (absolute path, ~ expanded)
+
 # Optional: per-hook env. Written to .cursor/hooks.env; source it before Cursor to apply.
 # env:
 #   HOOK_MAX_FILE_LINES: "500"

--- a/scripts/summary.sh
+++ b/scripts/summary.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Print audit and cost summary. Uses HOOK_AUDIT_DIR and HOOK_COST_DIR or ~/.cursor/audit and ~/.cursor/cost.
+# Print audit and cost summary. Uses HOOK_AUDIT_DIR and HOOK_COST_DIR or ~/.config/hooks/audit and ~/.config/hooks/cost.
 # Audit: line count from log files modified in last 24h (approximate). Cost: sum of tokens from cost.log.
 set -euo pipefail
-AUDIT_DIR="${HOOK_AUDIT_DIR:-$HOME/.cursor/audit}"
-COST_DIR="${HOOK_COST_DIR:-$HOME/.cursor/cost}"
+AUDIT_DIR="${HOOK_AUDIT_DIR:-$HOME/.config/hooks/audit}"
+COST_DIR="${HOOK_COST_DIR:-$HOME/.config/hooks/cost}"
 calls=0
 tokens=0
 


### PR DESCRIPTION
## Summary

- Add `output` section to `config.yaml` for configuring `binDir`, `cursorDir`, `claudeDir`, and `globalDir` with precedence: env var > config.yaml > hardcoded defaults
- Move default hook data directory from `~/.cursor/<subdir>` to `~/.config/hooks/<subdir>` (audit, cost, time, rate, diary, snapshots, dry-run, todos) to decouple from any specific editor
- Support writing `hooks.json` to a global directory (e.g. `~/.cursor`) when `globalDir` is configured

## Test plan

- [x] `go test -v -count=1 ./...` — all tests pass
- [x] `gofmt -l .` — clean
- [x] `make all && make config` — generates files to correct paths
- [ ] Verify generated JSON uses configured `binDir` prefix when set
- [ ] Test with `globalDir: ~/.cursor` and confirm it writes there
- [ ] Verify env var overrides still take precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options to customize output directories for hooks (binary, cursor, claude, and global config paths).
  * Added support for global hooks configuration file placement.
  * Environment variables now allow overriding cursor and claude directory paths.

* **Chores**
  * Relocated default hook data directories from ~/.cursor to ~/.config/hooks, aligning with standard directory conventions.
  * Updated configuration documentation with new output path options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->